### PR TITLE
Bugfix

### DIFF
--- a/assets/styles/css/style.css
+++ b/assets/styles/css/style.css
@@ -313,6 +313,9 @@ code {
 
 .card_description {
   padding-bottom: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
+  width: 300px;
   margin-bottom: 50px;
   margin-right: 50px;
   margin-left: auto;


### PR DESCRIPTION
I think I fixed the issue in the How It works section. The problem was that the card description boxes didn't have a set width, so they were much wider than the images.